### PR TITLE
LMSDEV-1338

### DIFF
--- a/block_aprende_coursenavigation.php
+++ b/block_aprende_coursenavigation.php
@@ -620,8 +620,7 @@ class block_aprende_coursenavigation extends block_base {
         // The settings are defined, validate them
         $cminlist = in_array($cm->id, explode(",", $course->activitiessection));
         $useristarget = array_key_exists('folio', $USER->profile) && (int)$USER->profile['folio'] > 0 &&
-            (int)$USER->profile['folio'] % 2 == 0;
-
+            (int)$USER->profile['folio'] % 2 == 0 && get_config('format_aprendetopics', 'enable_activities_ab_test') == 1;
         return  $cminlist && $useristarget;
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 06/21/2021
+- fix: AP tab enabled for everyone when the A/B experiment is off
 ## 06/07/2021
 - fix: missing compiled JS files added
 


### PR DESCRIPTION
fix: AP tab enabled for everyone when the A/B experiment is off